### PR TITLE
Add validators for skill proficiency range

### DIFF
--- a/backend/portfolio_backend/api/models.py
+++ b/backend/portfolio_backend/api/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.validators import MinValueValidator, MaxValueValidator
 
 def project_image_path(instance, filename):
     """Generate file path for project images"""
@@ -38,7 +39,9 @@ class Project(models.Model):
 
 class Skill(models.Model):
     name = models.CharField(max_length=100)
-    proficiency = models.IntegerField(default=0)  # 0-100
+    proficiency = models.IntegerField(
+        default=0, validators=[MinValueValidator(0), MaxValueValidator(100)]
+    )  # 0-100
     category = models.CharField(max_length=100, blank=True)
     
     class Meta:


### PR DESCRIPTION
## Summary
- import MinValueValidator/MaxValueValidator
- constrain Skill.proficiency between 0 and 100

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rest_framework_simplejwt')*
- `pip install djangorestframework-simplejwt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a775d946608323b60d35a92738e831