### PR TITLE
Guard console logs to run only in development

### DIFF
--- a/frontend/src/components/ApiTest.tsx
+++ b/frontend/src/components/ApiTest.tsx
@@ -13,10 +13,14 @@ const ApiTest: React.FC = () => {
       setError(null);
       
       const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000/api';
-      console.log(`Testing API: ${apiUrl}${endpoint}`);
-      
+      if (import.meta.env.DEV) {
+        console.log(`Testing API: ${apiUrl}${endpoint}`);
+      }
+
       const response = await axios.get(`${apiUrl}${endpoint}`);
-      console.log('API Response:', response);
+      if (import.meta.env.DEV) {
+        console.log('API Response:', response);
+      }
       setData(response.data);
     } catch (err: any) {
       console.error('API Test Error:', err);

--- a/frontend/src/components/TestProjects.tsx
+++ b/frontend/src/components/TestProjects.tsx
@@ -12,7 +12,9 @@ export default function TestProjects() {
         setLoading(true);
         // Use a direct URL to avoid any issues with environment variables
         const response = await axios.get('http://localhost:8000/api/projects/');
-        console.log('Direct API response:', response.data);
+        if (import.meta.env.DEV) {
+          console.log('Direct API response:', response.data);
+        }
         setData(response.data);
         setError(null);
       } catch (err: any) {

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -28,13 +28,19 @@ export function useProjects() {
     const fetchProjects = async () => {
       try {
         setLoading(true);
-        console.log("Fetching projects...");
+        if (import.meta.env.DEV) {
+          console.log("Fetching projects...");
+        }
         const response = await projectsApi.getAll();
-        console.log("API response:", response);
+        if (import.meta.env.DEV) {
+          console.log("API response:", response);
+        }
         
         // Handle both paginated and non-paginated responses
         const projectsData = response.data.results || response.data;
-        console.log("Projects data:", projectsData);
+        if (import.meta.env.DEV) {
+          console.log("Projects data:", projectsData);
+        }
         
         setProjects(projectsData);
         setError(null);


### PR DESCRIPTION
## Summary
- wrap API test console.logs with `import.meta.env.DEV`
- guard test project logs behind dev flag
- only log project fetching when running in development

## Testing
- `npm install` (fails: 403 Forbidden - cannot access registry)
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a775d844a88323badcb9965e4e41b1