### PR TITLE
feat: temporarily disable blog routes

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -1,23 +1,21 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
-import Blog from './components/Blog';
-import BlogDetail from './components/BlogDetail';
 import Comms from './components/Comms';
 import Profiles from './components/Profiles';
-import Journal from './components/Journal';
 import JobMatch from './components/JobMatch';
 import ProjectBot from './components/ProjectBot';
+import ComingSoon from './components/ComingSoon';
 
 export default function Root() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<App />} />
-        <Route path="/blog" element={<Blog />} />
-        <Route path="/blog/:slug" element={<BlogDetail />} />
+        <Route path="/blog" element={<ComingSoon />} />
+        <Route path="/blog/:slug" element={<ComingSoon />} />
         <Route path="/docs" element={<Comms />} />
         <Route path="/profiles" element={<Profiles />} />
-        <Route path="/journal" element={<Journal />} />
+        <Route path="/journal" element={<ComingSoon />} />
         <Route path="/ai/job-match" element={<JobMatch />} />
         <Route path="/ai/project-bot" element={<ProjectBot />} />
       </Routes>

--- a/frontend/src/components/ComingSoon.tsx
+++ b/frontend/src/components/ComingSoon.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ComingSoon() {
+  return (
+    <section className="p-8 max-w-4xl mx-auto text-center">
+      <h1 className="text-3xl font-bold mb-4 text-slate-900 dark:text-white">Coming Soon</h1>
+      <p className="text-slate-700 dark:text-slate-300">
+        Blog content isn't available yet. Check back later!
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- temporarily disable blog routes until backend is ready
- add simple Coming Soon placeholder component

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: lint errors)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a775d7fdac83238b41eb421587c15e