### PR TITLE
fix: route contact submissions to comms endpoint

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -34,7 +34,7 @@ export const blogApi = {
 };
 
 export const contactApi = {
-  submit: (data: unknown) => api.post('/contacts/', data),
+  submit: (data: unknown) => api.post('/comms/', data),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- update contact API to post to `/comms/` instead of `/contacts/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-google-recaptcha)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-google-recaptcha)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a775d7e6888323806bd4769af2d695