### PR TITLE
Wrap OpenAI chat completion in try/except

### DIFF
--- a/backend/portfolio_backend/api/views.py
+++ b/backend/portfolio_backend/api/views.py
@@ -154,10 +154,17 @@ class AIChatView(APIView):
         api_key = os.getenv('OPENAI_API_KEY')
         if not api_key:
             return Response({'response': f'Echo: {prompt}'})
-        client = openai.OpenAI(api_key=api_key)
-        completion = client.chat.completions.create(
-            model='gpt-3.5-turbo',
-            messages=[{'role': 'user', 'content': prompt}]
-        )
-        text = completion.choices[0].message.content
-        return Response({'response': text})
+        try:
+            client = openai.OpenAI(api_key=api_key)
+            completion = client.chat.completions.create(
+                model='gpt-3.5-turbo',
+                messages=[{'role': 'user', 'content': prompt}]
+            )
+            text = completion.choices[0].message.content
+            return Response({'response': text})
+        except Exception as e:
+            logger.exception("OpenAI completion failed")
+            return Response(
+                {'error': 'Service temporarily unavailable', 'details': str(e)},
+                status=503,
+            )


### PR DESCRIPTION
## Summary
- handle OpenAI API failures in AIChatView.post with try/except
- log errors and return a 503 response when the OpenAI service is unavailable

## Testing
- `uv run pytest` *(fails: Failed to fetch: `https://pypi.org/simple/openai/`)*

------
https://chatgpt.com/codex/tasks/task_e_68a775d7b7c48323b33081401f127121