### PR TITLE
feat: add auth token interceptor

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,16 @@ const api = axios.create({
   timeout: 10000,
 });
 
+// Automatically attach the Authorization header if a token exists
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 
 export const projectsApi = {
   getAll: () => api.get('/projects/'),


### PR DESCRIPTION
## Summary
- add request interceptor to attach bearer token automatically

## Testing
- `npm run lint` (fails: Unexpected any, ...)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a775d788e483238ea90a3ff3137780