### PR TITLE
feat: add torch requirement for KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ A modern, full-stack portfolio application built with React (frontend) and Djang
 ## Local AI (no OpenAI)
 
 - Install Ollama → `ollama pull llama3.1:8b`
+- Install KB dependencies (CPU wheel):
+  ```bash
+  pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements-kb.txt
+  ```
 - Prepare DB/media/seed:
   ```
   cd backend/portfolio_backend

--- a/backend/requirements-kb.txt
+++ b/backend/requirements-kb.txt
@@ -1,0 +1,5 @@
+sentence-transformers
+faiss-cpu
+pdfplumber
+unidecode
+torch==2.2.2


### PR DESCRIPTION
## Summary
- document using CPU wheel when installing KB dependencies
- add requirements-kb.txt with pinned torch version

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu torch==2.2.2` (fails: Could not find a version that satisfies the requirement torch==2.2.2)
- `python - <<'PY'
import torch
import sentence_transformers
print('versions', torch.__version__, sentence_transformers.__version__)
PY`
- `python -m py_compile backend/portfolio_backend/api/build_kb.py backend/portfolio_backend/api/local_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68a81d31471083238c25401adf93715d