### PR TITLE
feat: separate KB dependencies

### DIFF
--- a/backend/requirements-kb.txt
+++ b/backend/requirements-kb.txt
@@ -1,0 +1,4 @@
+sentence-transformers
+faiss-cpu
+pdfplumber
+unidecode

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,3 @@ djangorestframework-simplejwt
 django-ratelimit
 requests
 Pillow
-sentence-transformers
-faiss-cpu
-pdfplumber
-unidecode

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+## Knowledge Base Dependencies
+
+If you need the knowledge base features, install the optional dependencies with:
+
+```bash
+pip install -r backend/requirements-kb.txt
+```
+


### PR DESCRIPTION
## Summary
- move knowledge base packages to `backend/requirements-kb.txt`
- remove optional KB packages from main backend requirements
- document optional KB installation in `docs/README.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81d3633308323ae5c3a5b3415505c