### PR TITLE
Refactor router for new React Router API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+venv/
+node_modules/

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App';
 import Comms from './components/Comms';
 import Profiles from './components/Profiles';
@@ -7,19 +7,22 @@ import ProjectBot from './components/ProjectBot';
 import Journal from './components/Journal';
 import ComingSoon from './components/ComingSoon';
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { path: 'blog', element: <ComingSoon /> },
+      { path: 'blog/:slug', element: <ComingSoon /> },
+      { path: 'docs', element: <Comms /> },
+      { path: 'profiles', element: <Profiles /> },
+      { path: 'journal', element: <Journal /> },
+      { path: 'ai/job-match', element: <JobMatch /> },
+      { path: 'ai/project-bot', element: <ProjectBot /> },
+    ],
+  },
+]);
+
 export default function Root() {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />} />
-          <Route path="/blog" element={<ComingSoon />} />
-          <Route path="/blog/:slug" element={<ComingSoon />} />
-          <Route path="/docs" element={<Comms />} />
-          <Route path="/profiles" element={<Profiles />} />
-          <Route path="/journal" element={<Journal />} />
-          <Route path="/ai/job-match" element={<JobMatch />} />
-          <Route path="/ai/project-bot" element={<ProjectBot />} />
-      </Routes>
-    </BrowserRouter>
-  );
+  return <RouterProvider router={router} />;
 }


### PR DESCRIPTION
## Summary
- refactor Root component to use `createBrowserRouter` and `RouterProvider`
- ignore virtualenv and node modules

## Testing
- `python backend/portfolio_backend/manage.py test` (fails: ModuleNotFoundError: No module named 'django')
- `npx tsc --noEmit --project frontend/tsconfig.json` (fails: missing dependencies)
- `npm run build --prefix frontend` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a84d7a318c83239ebe167d954e1ce2