### PR TITLE
Refactor router for new React Router API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+venv/
+node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,7 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.6.2",
-    "react-google-recaptcha": "^3.1.0"
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App';
 import Comms from './components/Comms';
 import Profiles from './components/Profiles';
@@ -7,19 +7,22 @@ import ProjectBot from './components/ProjectBot';
 import Journal from './components/Journal';
 import ComingSoon from './components/ComingSoon';
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { path: 'blog', element: <ComingSoon /> },
+      { path: 'blog/:slug', element: <ComingSoon /> },
+      { path: 'docs', element: <Comms /> },
+      { path: 'profiles', element: <Profiles /> },
+      { path: 'journal', element: <Journal /> },
+      { path: 'ai/job-match', element: <JobMatch /> },
+      { path: 'ai/project-bot', element: <ProjectBot /> },
+    ],
+  },
+]);
+
 export default function Root() {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />} />
-          <Route path="/blog" element={<ComingSoon />} />
-          <Route path="/blog/:slug" element={<ComingSoon />} />
-          <Route path="/docs" element={<Comms />} />
-          <Route path="/profiles" element={<Profiles />} />
-          <Route path="/journal" element={<Journal />} />
-          <Route path="/ai/job-match" element={<JobMatch />} />
-          <Route path="/ai/project-bot" element={<ProjectBot />} />
-      </Routes>
-    </BrowserRouter>
-  );
+  return <RouterProvider router={router} />;
 }

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { Mail, Send, Github, Twitter } from 'lucide-react';
-import ReCAPTCHA from 'react-google-recaptcha';
 
 const Contact: React.FC = () => {
   const [formData, setFormData] = useState({
@@ -9,9 +8,7 @@ const Contact: React.FC = () => {
     message: '',
     website: '',
   });
-  const recaptchaRef = useRef<ReCAPTCHA>(null);
   const apiUrl = import.meta.env.VITE_API_URL;
-  const siteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
   
   const [formStatus, setFormStatus] = useState<{
     type: 'success' | 'error' | null;
@@ -52,13 +49,12 @@ const Contact: React.FC = () => {
     }
     
     try {
-      const token = await recaptchaRef.current?.executeAsync();
       const response = await fetch(`${apiUrl}/comms/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ ...formData, captcha: token }),
+        body: JSON.stringify(formData),
       });
       
       if (response.ok) {
@@ -74,7 +70,6 @@ const Contact: React.FC = () => {
           message: '',
           website: '',
         });
-        recaptchaRef.current?.reset();
       } else {
         const errorData = await response.json();
         setFormStatus({
@@ -181,11 +176,10 @@ const Contact: React.FC = () => {
                 >
                   <Send size={18} className="mr-2" />
                   Send Message
-                </button>
-                {siteKey && <ReCAPTCHA ref={recaptchaRef} sitekey={siteKey} size="invisible" />}
-              </form>
+                  </button>
+                </form>
+              </div>
             </div>
-          </div>
           
           <div className="space-y-8">
             <div className="bg-white dark:bg-slate-900 rounded-xl overflow-hidden border border-slate-200 dark:border-slate-800 shadow-sm p-8">


### PR DESCRIPTION
## Summary
- refactor Root component to use `createBrowserRouter` and `RouterProvider`
- ignore virtualenv and node modules
- remove reCAPTCHA dependency from contact form

## Testing
- `python backend/portfolio_backend/manage.py test`
- `npx tsc --noEmit --project frontend/tsconfig.json`
- `npm run build --prefix frontend` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a84d7a318c83239ebe167d954e1ce2