### PR TITLE
Fix CI lint and TypeScript checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,11 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          pip install -r backend/requirements.txt flake8 ruff
+          pip install -r backend/requirements.txt ruff
       - name: Migrate
         run: python backend/portfolio_backend/manage.py migrate --noinput
       - name: Lint
-        run: |
-          flake8 backend/portfolio_backend
-          ruff backend/portfolio_backend
+        run: ruff check backend/portfolio_backend
       - name: Tests
         run: python backend/portfolio_backend/manage.py test
 
@@ -34,6 +32,6 @@ jobs:
       - name: Install
         run: npm ci --prefix frontend
       - name: Typecheck
-        run: npx tsc --noEmit --project frontend/tsconfig.json
+        run: npm run typecheck --prefix frontend
       - name: Build
         run: npm run build --prefix frontend

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -45,6 +45,10 @@ export const projectsApi = {
   getAll: () => api.get('/projects/'),
 };
 
+export const skillsApi = {
+  getAll: () => api.get('/skills/'),
+};
+
 export const contactApi = {
   submit: (data: unknown) => api.post('/contact/', data),
 };


### PR DESCRIPTION
## Summary
- use ruff for Python linting and drop flake8
- run frontend TypeScript checks via npm script
- export skills API helper for frontend build

## Testing
- `ruff check backend/portfolio_backend`
- `python backend/portfolio_backend/manage.py test`
- `npm run typecheck --prefix frontend` *(fails: tsc not found)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a861c4f5d883239970b182d26e60aa