### PR TITLE
refactor: hash-based sections and lazy loading

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+- Use hash-based section IDs (e.g., `#journal`) when adding new features.
+- Prefer lazy-loaded modules with `React.lazy` and `<Suspense>` wrappers.
+- Fetch data lazily by combining `useInView` with `AbortController` cleanup.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,10 +7,9 @@ A modern, responsive portfolio website built with React, TypeScript, and Tailwin
 - 🌓 Dark/Light theme toggle
 - 📱 Fully responsive design
 - 🎨 Modern UI with smooth animations
-- 🎯 Interactive project filtering
-- 📊 Visual skill progress indicators
-- 📝 Contact form with validation
-- 🔄 Smooth scroll navigation
+- 📰 Journal, AI Job Match, Project Bot, Docs, and Profiles sections
+- ⏱️ Lazy-loaded feature modules
+- 🔄 Smooth scroll navigation via hash anchors
 
 ## Tech Stack
 
@@ -37,18 +36,22 @@ A modern, responsive portfolio website built with React, TypeScript, and Tailwin
 ```
 src/
 ├── components/     # React components
-├── data/          # Data files
-├── App.tsx        # Main application component
+├── hooks/          # Reusable hooks (e.g., useInView)
+├── App.tsx        # Main single-page application with hash sections
 └── main.tsx       # Application entry point
 ```
 
+## Single-page Sections
+
+Each major feature renders within a `<section id="...">` block in `App.tsx`.
+Anchors follow the format `#feature-name` (e.g., `#journal`, `#job-match`).
+Feature modules are lazy-loaded and fetch data only when scrolled into view.
+
 ## Customization
 
-1. Update personal information in `Hero.tsx`
-2. Modify projects in `Projects.tsx`
-3. Update skills in `Skills.tsx`
-4. Edit experience timeline in `Experience.tsx`
-5. Customize contact information in `Contact.tsx`
+1. Update API endpoints in `src/services/api.ts`
+2. Adjust section IDs and navigation links in `App.tsx` and `Navbar.tsx`
+3. Extend lazy-loaded features by following the existing section pattern
 
 ## Building for Production
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,47 @@
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import Navbar from './components/Navbar';
-import Hero from './components/Hero';
-import About from './components/About';
-import Skills from './components/Skills';
-import Projects from './components/Projects';
-import Experience from './components/Experience';
-import Contact from './components/Contact';
-import Footer from './components/Footer';
+
+const Journal = lazy(() => import('./components/Journal'));
+const JobMatch = lazy(() => import('./components/JobMatch'));
+const ProjectBot = lazy(() => import('./components/ProjectBot'));
+const Comms = lazy(() => import('./components/Comms'));
+const Profiles = lazy(() => import('./components/Profiles'));
 
 function App() {
-  // Add smooth scrolling for anchor links
   useEffect(() => {
+    const legacyMap: Record<string, string> = {
+      '/journal': '#journal',
+      '/ai/job-match': '#job-match',
+      '/ai/project-bot': '#project-bot',
+      '/docs': '#docs',
+      '/profiles': '#profiles',
+    };
+
+    const navigateToHash = (hash: string) => {
+      const element = document.querySelector(hash);
+      if (element) {
+        window.history.replaceState(null, '', `/${hash}`);
+        window.scrollTo({
+          top: element.getBoundingClientRect().top + window.pageYOffset - 80,
+          behavior: 'smooth',
+        });
+      }
+    };
+
+    const initialHash = legacyMap[window.location.pathname] || window.location.hash;
+    if (initialHash) {
+      navigateToHash(initialHash);
+    }
+
     const handleAnchorClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
-      if (target.tagName === 'A' && target.getAttribute('href')?.startsWith('#')) {
+      if (target.tagName !== 'A') return;
+      const href = target.getAttribute('href');
+      if (!href) return;
+      const hash = href.startsWith('#') ? href : legacyMap[href];
+      if (hash) {
         e.preventDefault();
-        const href = target.getAttribute('href') as string;
-        const element = document.querySelector(href);
-        if (element) {
-          window.scrollTo({
-            top: element.getBoundingClientRect().top + window.pageYOffset - 80,
-            behavior: 'smooth'
-          });
-        }
+        navigateToHash(hash);
       }
     };
 
@@ -34,14 +53,32 @@ function App() {
     <div className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-white">
       <Navbar />
       <main>
-        <Hero />
-        <About />
-        <Skills />
-        <Projects />
-        <Experience />
-        <Contact />
+        <section id="journal">
+          <Suspense fallback={<div>Loading...</div>}>
+            <Journal />
+          </Suspense>
+        </section>
+        <section id="job-match">
+          <Suspense fallback={<div>Loading...</div>}>
+            <JobMatch />
+          </Suspense>
+        </section>
+        <section id="project-bot">
+          <Suspense fallback={<div>Loading...</div>}>
+            <ProjectBot />
+          </Suspense>
+        </section>
+        <section id="docs">
+          <Suspense fallback={<div>Loading...</div>}>
+            <Comms />
+          </Suspense>
+        </section>
+        <section id="profiles">
+          <Suspense fallback={<div>Loading...</div>}>
+            <Profiles />
+          </Suspense>
+        </section>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -1,26 +1,16 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import App from './App';
-import Comms from './components/Comms';
-import Profiles from './components/Profiles';
-import JobMatch from './components/JobMatch';
-import ProjectBot from './components/ProjectBot';
-import Journal from './components/Journal';
-import ComingSoon from './components/ComingSoon';
 
 const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <App />,
-    children: [
-      { path: 'blog', element: <ComingSoon /> },
-      { path: 'blog/:slug', element: <ComingSoon /> },
-      { path: 'docs', element: <Comms /> },
-      { path: 'profiles', element: <Profiles /> },
-      { path: 'journal', element: <Journal /> },
-      { path: 'ai/job-match', element: <JobMatch /> },
-      { path: 'ai/project-bot', element: <ProjectBot /> },
-    ],
-  },
+  { path: '/', element: <App /> },
+  { path: '/journal', element: <Navigate to="/#journal" replace /> },
+  { path: '/ai/job-match', element: <Navigate to="/#job-match" replace /> },
+  { path: '/ai/project-bot', element: <Navigate to="/#project-bot" replace /> },
+  { path: '/docs', element: <Navigate to="/#docs" replace /> },
+  { path: '/profiles', element: <Navigate to="/#profiles" replace /> },
+  { path: '/blog', element: <Navigate to="/#journal" replace /> },
+  { path: '/blog/:slug', element: <Navigate to="/#journal" replace /> },
+  { path: '*', element: <Navigate to="/" replace /> },
 ]);
 
 export default function Root() {

--- a/frontend/src/components/JobMatch.tsx
+++ b/frontend/src/components/JobMatch.tsx
@@ -1,97 +1,124 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Meta from './Meta';
+import useInView from '../hooks/useInView';
 import { aiApi } from '../services/api';
 
-  interface JobMatchResult {
-    match_score: number;
-    rationale: string;
-    strengths: string[];
-    gaps: string[];
-    pitch: string;
-    keywords: string[];
-  }
+interface JobMatchResult {
+  match_score: number;
+  rationale: string;
+  strengths: string[];
+  gaps: string[];
+  pitch: string;
+  keywords: string[];
+}
 
 export default function JobMatch() {
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<JobMatchResult | null>(null);
+  const { ref, inView } = useInView<HTMLDivElement>();
+  const [open, setOpen] = useState(false);
+  const controllerRef = useRef<AbortController | null>(null);
 
   const analyze = async () => {
     setLoading(true);
-      try {
-        const res = await aiApi.jobMatchAnalyze({ job_description: text });
-        setResult(res.data);
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    try {
+      const res = await aiApi.jobMatchAnalyze(
+        { job_description: text },
+        { signal: controller.signal },
+      );
+      setResult(res.data);
     } catch (err) {
-      console.error(err);
-          setResult({
-            match_score: 0,
-            rationale: 'No analysis available.',
-            strengths: [],
-            gaps: [],
-            pitch: '',
-            keywords: [],
-          });
+      if (!controller.signal.aborted) {
+        console.error(err);
+        setResult({
+          match_score: 0,
+          rationale: 'No analysis available.',
+          strengths: [],
+          gaps: [],
+          pitch: '',
+          keywords: [],
+        });
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  return (
-    <section className="p-8 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Job Match Analyzer</h1>
-      <textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        rows={6}
-        className="w-full border rounded-md p-2 mb-4"
-      />
-      <button
-        onClick={analyze}
-        disabled={loading}
-        className="px-4 py-2 bg-teal-600 text-white rounded-md disabled:opacity-50"
-      >
-        {loading ? 'Analyzing...' : 'Analyze'}
-      </button>
+  useEffect(() => () => controllerRef.current?.abort(), []);
 
-      {result && (
-        <div className="mt-6 space-y-4">
-          <div>
-              <strong>Score:</strong> {result.match_score}
-          </div>
-          <div>
-            <strong>Rationale:</strong> {result.rationale}
-          </div>
-          {result.strengths.length > 0 && (
-            <div>
-              <strong>Strengths:</strong>
-              <ul className="list-disc list-inside">
-                {result.strengths.map((s, i) => (
-                  <li key={i}>{s}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {result.gaps.length > 0 && (
-            <div>
-              <strong>Gaps:</strong>
-              <ul className="list-disc list-inside">
-                {result.gaps.map((g, i) => (
-                  <li key={i}>{g}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {result.pitch && (
-            <div>
-              <strong>Pitch:</strong> {result.pitch}
-            </div>
-          )}
-          {result.keywords.length > 0 && (
-            <div>
-              <strong>Keywords:</strong> {result.keywords.join(', ')}
-            </div>
-          )}
-        </div>
-      )}
-    </section>
+  return (
+    <div
+      ref={ref}
+      aria-labelledby="job-match-heading"
+      className="p-8 max-w-3xl mx-auto"
+    >
+      <Meta title="Job Match" description="Analyze job descriptions" />
+      <details onToggle={(e) => setOpen(e.currentTarget.open)}>
+        <summary id="job-match-heading" className="text-2xl font-bold mb-4">
+          Job Match Analyzer
+        </summary>
+        {inView && open && (
+          <>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={6}
+              className="w-full border rounded-md p-2 mb-4"
+            />
+            <button
+              onClick={analyze}
+              disabled={loading}
+              className="px-4 py-2 bg-teal-600 text-white rounded-md disabled:opacity-50"
+            >
+              {loading ? 'Analyzing...' : 'Analyze'}
+            </button>
+
+            {result && (
+              <div className="mt-6 space-y-4">
+                <div>
+                  <strong>Score:</strong> {result.match_score}
+                </div>
+                <div>
+                  <strong>Rationale:</strong> {result.rationale}
+                </div>
+                {result.strengths.length > 0 && (
+                  <div>
+                    <strong>Strengths:</strong>
+                    <ul className="list-disc list-inside">
+                      {result.strengths.map((s, i) => (
+                        <li key={i}>{s}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {result.gaps.length > 0 && (
+                  <div>
+                    <strong>Gaps:</strong>
+                    <ul className="list-disc list-inside">
+                      {result.gaps.map((g, i) => (
+                        <li key={i}>{g}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {result.pitch && (
+                  <div>
+                    <strong>Pitch:</strong> {result.pitch}
+                  </div>
+                )}
+                {result.keywords.length > 0 && (
+                  <div>
+                    <strong>Keywords:</strong> {result.keywords.join(', ')}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </details>
+    </div>
   );
 }

--- a/frontend/src/components/Journal.tsx
+++ b/frontend/src/components/Journal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
+import Meta from './Meta';
+import useInView from '../hooks/useInView';
 import { blogApi } from '../services/api';
-import { Link } from 'react-router-dom';
 
 interface BlogPost {
   id: number;
@@ -12,23 +13,38 @@ interface BlogPost {
 
 export default function Journal() {
   const [posts, setPosts] = useState<BlogPost[]>([]);
+  const { ref, inView } = useInView<HTMLDivElement>();
 
   useEffect(() => {
+    if (!inView || posts.length) return;
+    const controller = new AbortController();
     blogApi
-      .list('journal')
+      .list(undefined, { signal: controller.signal })
       .then((res) => setPosts(res.data))
-      .catch((err) => console.error('Failed to load journal', err));
-  }, []);
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to load journal', err);
+        }
+      });
+    return () => controller.abort();
+  }, [inView, posts.length]);
 
   return (
-    <section className="p-8 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Journal</h1>
+    <div
+      ref={ref}
+      aria-labelledby="journal-heading"
+      className="p-8 max-w-4xl mx-auto"
+    >
+      <Meta title="Journal" description="Personal journal and blog posts" />
+      <h2 id="journal-heading" className="text-2xl font-bold mb-4">
+        Journal
+      </h2>
       <ul className="space-y-6">
         {posts.map((post) => (
           <li key={post.id}>
-            <h2 className="text-xl font-semibold text-teal-600">
-              <Link to={`/blog/${post.slug}`}>{post.title}</Link>
-            </h2>
+            <h3 className="text-xl font-semibold text-teal-600">
+              {post.title}
+            </h3>
             <p className="text-sm text-slate-500 mb-2">
               {new Date(post.created_at).toLocaleDateString('en-US', {
                 year: 'numeric',
@@ -40,6 +56,6 @@ export default function Journal() {
           </li>
         ))}
       </ul>
-    </section>
+    </div>
   );
 }

--- a/frontend/src/components/Meta.tsx
+++ b/frontend/src/components/Meta.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+interface MetaProps {
+  title: string;
+  description?: string;
+}
+
+export default function Meta({ title, description }: MetaProps) {
+  useEffect(() => {
+    document.title = title;
+    if (description) {
+      let meta = document.querySelector('meta[name="description"]');
+      if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'description');
+        document.head.appendChild(meta);
+      }
+      meta.setAttribute('content', description);
+    }
+  }, [title, description]);
+  return null;
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,12 +24,11 @@ const Navbar: React.FC = () => {
   };
 
   const navLinks = [
-    { name: 'Home', href: '#home' },
-    { name: 'About', href: '#about' },
-    { name: 'Skills', href: '#skills' },
-    { name: 'Projects', href: '#projects' },
-    { name: 'Experience', href: '#experience' },
-    { name: 'Contact', href: '#contact' },
+    { name: 'Journal', href: '#journal' },
+    { name: 'Job Match', href: '#job-match' },
+    { name: 'Project Bot', href: '#project-bot' },
+    { name: 'Docs', href: '#docs' },
+    { name: 'Profiles', href: '#profiles' },
   ];
 
   return (

--- a/frontend/src/components/Profiles.tsx
+++ b/frontend/src/components/Profiles.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import Meta from './Meta';
+import useInView from '../hooks/useInView';
 import { profilesApi } from '../services/api';
 
 interface SocialProfile {
@@ -10,17 +12,32 @@ interface SocialProfile {
 
 export default function Profiles() {
   const [profiles, setProfiles] = useState<SocialProfile[]>([]);
+  const { ref, inView } = useInView<HTMLDivElement>();
 
   useEffect(() => {
+    if (!inView || profiles.length) return;
+    const controller = new AbortController();
     profilesApi
-      .list()
+      .list({ signal: controller.signal })
       .then((res) => setProfiles(res.data))
-      .catch((err) => console.error('Failed to load profiles', err));
-  }, []);
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to load profiles', err);
+        }
+      });
+    return () => controller.abort();
+  }, [inView, profiles.length]);
 
   return (
-    <section className="p-8 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Social Profiles</h1>
+    <div
+      ref={ref}
+      aria-labelledby="profiles-heading"
+      className="p-8 max-w-3xl mx-auto"
+    >
+      <Meta title="Profiles" description="Social media profiles" />
+      <h2 id="profiles-heading" className="text-2xl font-bold mb-4">
+        Social Profiles
+      </h2>
       <ul className="space-y-2">
         {profiles.map((profile) => (
           <li key={profile.id}>
@@ -35,6 +52,6 @@ export default function Profiles() {
           </li>
         ))}
       </ul>
-    </section>
+    </div>
   );
 }

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useInView<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+        }
+      });
+    });
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return { ref, inView };
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosRequestConfig } from 'axios';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -22,27 +22,35 @@ api.interceptors.request.use((config) => {
 });
 
 export const aiApi = {
-  jobMatchAnalyze: (data: { job_description: string }) =>
-    api.post('/ai/jobmatch/analyze/', data),
-  projectExplainerChat: (data: { question: string; project_ids?: number[] }) =>
-    api.post('/ai/project-explainer/chat/', data),
+  jobMatchAnalyze: (
+    data: { job_description: string },
+    config?: AxiosRequestConfig,
+  ) => api.post('/ai/jobmatch/analyze/', data, config),
+  projectExplainerChat: (
+    data: { question: string; project_ids?: number[] },
+    config?: AxiosRequestConfig,
+  ) => api.post('/ai/project-explainer/chat/', data, config),
 };
 
 export const commsApi = {
-  list: () => api.get('/comms/'),
+  list: (config?: AxiosRequestConfig) => api.get('/comms/', config),
 };
 
 export const profilesApi = {
-  list: () => api.get('/profiles/'),
+  list: (config?: AxiosRequestConfig) => api.get('/profiles/', config),
 };
 
 export const blogApi = {
-  list: (params?: Record<string, unknown>) => api.get('/blog/', { params }),
-  getBySlug: (slug: string) => api.get(`/blog/${slug}/`),
+  list: (
+    params?: Record<string, unknown>,
+    config?: AxiosRequestConfig,
+  ) => api.get('/blog/', { params, ...config }),
+  getBySlug: (slug: string, config?: AxiosRequestConfig) =>
+    api.get(`/blog/${slug}/`, config),
 };
 
 export const projectsApi = {
-  getAll: () => api.get('/projects/'),
+  getAll: (config?: AxiosRequestConfig) => api.get('/projects/', config),
 };
 
 export const skillsApi = {

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,28 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[redirects]]
+  from = "/journal"
+  to = "/#journal"
+  status = 301
+
+[[redirects]]
+  from = "/ai/job-match"
+  to = "/#job-match"
+  status = 301
+
+[[redirects]]
+  from = "/ai/project-bot"
+  to = "/#project-bot"
+  status = 301
+
+[[redirects]]
+  from = "/docs"
+  to = "/#docs"
+  status = 301
+
+[[redirects]]
+  from = "/profiles"
+  to = "/#profiles"
+  status = 301


### PR DESCRIPTION
## Summary
- route legacy paths to hash-based single page sections
- lazy load feature modules with in-view data fetching and metadata
- document hash navigation conventions and Netlify redirects

## Testing
- `npm run --prefix frontend typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a8705a1acc83238115c46e4d16c1b1