### PR TITLE
refactor: use shared api client for test projects

### DIFF
--- a/frontend/src/components/TestProjects.tsx
+++ b/frontend/src/components/TestProjects.tsx
@@ -1,32 +1,34 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { projectsApi } from '../services/api';
 
 export default function TestProjects() {
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isDev = import.meta.env.DEV;
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        // Use a direct URL to avoid any issues with environment variables
-        const response = await axios.get('http://localhost:8000/api/projects/');
-        if (import.meta.env.DEV) {
-          console.log('Direct API response:', response.data);
+        const response = await projectsApi.getAll();
+        if (isDev) {
+          console.log('Projects API response:', response.data);
         }
         setData(response.data);
         setError(null);
-      } catch (err: any) {
-        console.error('Error in test component:', err);
-        setError(err.message);
+      } catch (err: unknown) {
+        if (isDev) {
+          console.error('Error loading projects:', err);
+        }
+        setError('Failed to load projects. Please try again later.');
       } finally {
         setLoading(false);
       }
     };
 
     fetchData();
-  }, []);
+  }, [isDev]);
 
   return (
     <div className="p-8">


### PR DESCRIPTION
## Summary
- use shared `projectsApi` in test projects component instead of hardcoded URL
- log responses in dev and provide friendly error message on failure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a87b30cb78832393fb5faa9b6535b5