### PR TITLE
Add local fallback data for offline portfolio

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,6 +53,9 @@ Feature modules are lazy-loaded and fetch data only when scrolled into view.
 1. Update API endpoints in `src/services/api.ts`
 2. Adjust section IDs and navigation links in `App.tsx` and `Navbar.tsx`
 3. Extend lazy-loaded features by following the existing section pattern
+4. When the backend API is unavailable, the application falls back to local data
+   defined in `src/data`. Update these files to display your own projects,
+   profiles, documents and blog posts without a running server.
 
 ## Building for Production
 

--- a/frontend/src/components/Blog.tsx
+++ b/frontend/src/components/Blog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { blogApi, MEDIA_BASE } from '../services/api';
+import { fallbackPosts } from '../data/blogData';
 
 interface BlogPost {
   id: number;
@@ -19,7 +20,11 @@ export default function Blog() {
     blogApi
       .list()
       .then((res) => setPosts(res.data))
-      .catch((err) => console.error('Error fetching blog posts:', err))
+      .catch((err) => {
+        console.error('Error fetching blog posts:', err);
+        // Use fallback posts when API call fails
+        setPosts(fallbackPosts);
+      })
       .finally(() => setIsLoading(false));
   }, []);
 

--- a/frontend/src/components/BlogDetail.tsx
+++ b/frontend/src/components/BlogDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { blogApi, MEDIA_BASE } from '../services/api';
+import { fallbackPosts } from '../data/blogData';
 
 interface BlogPost {
   title: string;
@@ -19,7 +20,12 @@ export default function BlogDetail() {
     blogApi
       .getBySlug(slug)
       .then((res) => setPost(res.data))
-      .catch((err) => console.error('Failed to load post', err))
+      .catch((err) => {
+        console.error('Failed to load post', err);
+        // Use fallback content when API call fails
+        const local = fallbackPosts.find((p) => p.slug === slug);
+        if (local) setPost(local);
+      })
       .finally(() => setLoading(false));
   }, [slug]);
 

--- a/frontend/src/components/Comms.tsx
+++ b/frontend/src/components/Comms.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Meta from './Meta';
 import useInView from '../hooks/useInView';
 import { commsApi, MEDIA_BASE } from '../services/api';
+import { fallbackComms } from '../data/commsData';
 
 interface CommsDocument {
   id: number;
@@ -22,6 +23,8 @@ export default function Comms() {
       .catch((err) => {
         if (!controller.signal.aborted) {
           console.error('Failed to load documents', err);
+          // Use fallback documents when API call fails
+          setDocs(fallbackComms);
         }
       });
     return () => controller.abort();

--- a/frontend/src/components/Journal.tsx
+++ b/frontend/src/components/Journal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Meta from './Meta';
 import useInView from '../hooks/useInView';
 import { blogApi } from '../services/api';
+import { fallbackPosts } from '../data/blogData';
 
 interface BlogPost {
   id: number;
@@ -24,6 +25,8 @@ export default function Journal() {
       .catch((err) => {
         if (!controller.signal.aborted) {
           console.error('Failed to load journal', err);
+          // Use fallback posts when API call fails
+          setPosts(fallbackPosts);
         }
       });
     return () => controller.abort();

--- a/frontend/src/components/Profiles.tsx
+++ b/frontend/src/components/Profiles.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Meta from './Meta';
 import useInView from '../hooks/useInView';
 import { profilesApi } from '../services/api';
+import { fallbackProfiles } from '../data/profilesData';
 
 interface SocialProfile {
   id: number;
@@ -23,6 +24,8 @@ export default function Profiles() {
       .catch((err) => {
         if (!controller.signal.aborted) {
           console.error('Failed to load profiles', err);
+          // Use fallback data when API call fails
+          setProfiles(fallbackProfiles);
         }
       });
     return () => controller.abort();

--- a/frontend/src/data/blogData.ts
+++ b/frontend/src/data/blogData.ts
@@ -1,0 +1,24 @@
+export interface BlogPostData {
+  id: number;
+  title: string;
+  slug: string;
+  summary: string;
+  content: string;
+  image: string;
+  created_at: string;
+}
+
+// Default blog posts used when the backend API is unavailable.
+// Replace these with your own posts to customize the offline view.
+export const fallbackPosts: BlogPostData[] = [
+  {
+    id: 1,
+    title: 'Welcome to the Blog',
+    slug: 'welcome',
+    summary: 'Sample post shown when the API is offline.',
+    content: '<p>This is an example blog post used as fallback content.</p>',
+    image: '',
+    created_at: '2024-01-01',
+  },
+];
+

--- a/frontend/src/data/commsData.ts
+++ b/frontend/src/data/commsData.ts
@@ -1,0 +1,16 @@
+export interface CommsDocument {
+  id: number;
+  title: string;
+  file: string;
+}
+
+// Default documents used when the backend API is unavailable.
+// The file paths should point to assets available in the public folder.
+export const fallbackComms: CommsDocument[] = [
+  {
+    id: 1,
+    title: 'Sample Resume',
+    file: '#',
+  },
+];
+

--- a/frontend/src/data/profilesData.ts
+++ b/frontend/src/data/profilesData.ts
@@ -1,0 +1,18 @@
+export interface SocialProfile {
+  id: number;
+  platform: string;
+  handle: string;
+  url: string;
+}
+
+// Default profiles used when the backend API is unavailable.
+// Update these values to match your own social profiles.
+export const fallbackProfiles: SocialProfile[] = [
+  {
+    id: 1,
+    platform: 'GitHub',
+    handle: 'sample',
+    url: 'https://github.com/sample',
+  },
+];
+

--- a/frontend/src/data/projectsData.ts
+++ b/frontend/src/data/projectsData.ts
@@ -1,14 +1,32 @@
+export interface ProjectTechnology {
+  id: number;
+  name: string;
+}
+
 export interface ProjectData {
   id: number;
   title: string;
   description: string;
   image: string;
-  technologies: string[];
-  category: 'web' | 'cloud' | 'blockchain';
-  links: {
-    github: string | null;
-    live: string | null;
-  };
+  github_url: string | null;
+  live_url: string | null;
+  technologies: ProjectTechnology[];
 }
 
-// Projects data is defined in the Projects component directly for now
+// Default projects used when the backend API is unavailable.
+// Replace this data with your own projects to customize the offline view.
+export const fallbackProjects: ProjectData[] = [
+  {
+    id: 1,
+    title: 'Sample Project',
+    description: 'Displayed when the API is offline.',
+    image: '',
+    github_url: null,
+    live_url: null,
+    technologies: [
+      { id: 1, name: 'TypeScript' },
+      { id: 2, name: 'React' },
+    ],
+  },
+];
+


### PR DESCRIPTION
## Summary
- add static fallback data for projects, profiles, documents and blog posts
- load local data when API calls fail so portfolio still renders without backend
- document offline fallback behaviour

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab066cea7c8323a4c2bf330fd5e167