### PR TITLE
Add static HTML portfolio page

### DIFF
--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Didier IMANIRAHARI | Developer Portfolio</title>
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.6; margin: 0; padding: 0; background: #f8f9fa; color: #212529; }
+    header { background: #343a40; color: #fff; padding: 2rem 1rem; text-align: center; }
+    section { padding: 1.5rem; max-width: 900px; margin: auto; }
+    h2 { border-bottom: 2px solid #343a40; padding-bottom: .5rem; }
+    .contact p { margin: .25rem 0; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: .5rem; }
+    .project { margin-bottom: 1rem; }
+    .tech-list span { background: #e9ecef; margin-right: .25rem; padding: .25rem .5rem; border-radius: 4px; font-size: .85rem; }
+    footer { text-align: center; padding: 1rem; background: #343a40; color: #fff; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Didier IMANIRAHARI</h1>
+    <p>Developer</p>
+  </header>
+  <section class="summary">
+    <h2>Summary</h2>
+    <p>Software developer focused on Python/Django, blockchain, and cloud-native systems. Experienced with backend APIs, web automation, and smart contracts.</p>
+  </section>
+  <section class="contact">
+    <h2>Contact</h2>
+    <p>Kigali, Rwanda</p>
+    <p>Email: <a href="mailto:didier53053@gmail.com">didier53053@gmail.com</a></p>
+    <p>Phone: +250 782 953 053</p>
+    <p>GitHub: <a href="https://github.com/didier-building">didier-building</a></p>
+    <p>X/Twitter: <a href="https://x.com/didier53053">@didier53053</a></p>
+  </section>
+  <section class="education">
+    <h2>Education</h2>
+    <ul>
+      <li><strong>Bachelor’s in Computer and Software Engineering</strong>, University of Rwanda (Expected 2025)</li>
+    </ul>
+  </section>
+  <section class="certifications">
+    <h2>Certifications</h2>
+    <ul>
+      <li>Kubernetes and Cloud Native Essentials (LFS250) – The Linux Foundation</li>
+      <li>CCNAv7: Enterprise Networking, Security, and Automation – Cisco Networking Academy</li>
+      <li>CCNAv7: Introduction to Networks – Cisco Networking Academy</li>
+      <li>IT Essentials: PC Hardware and Software – Cisco Networking Academy</li>
+    </ul>
+  </section>
+  <section class="projects">
+    <h2>Projects</h2>
+    <div class="project">
+      <h3>Blockchain-Powered Agricultural Supply Chain System</h3>
+      <p><em>University of Rwanda (Capstone Project) – Project Lead</em></p>
+      <p>Blockchain-based platform for produce ownership transfer, price tracking, and supply chain transparency.</p>
+      <p class="tech-list"><span>Django REST</span><span>Vyper</span><span>Moccasin</span><span>Boa</span></p>
+    </div>
+    <div class="project">
+      <h3>E-Commerce Team Avatar</h3>
+      <p>Backend APIs for product listings, cart management, and order tracking.</p>
+      <p class="tech-list"><span>Django</span><span>Django REST Framework</span><span>PostgreSQL</span></p>
+    </div>
+    <div class="project">
+      <h3>NLPAY Academy</h3>
+      <p><em>Google Developers Hackathon – Team Lead</em></p>
+      <p>AI-powered platform delivering digital skills training in Kinyarwanda.</p>
+      <p class="tech-list"><span>Python</span><span>HTML</span><span>CSS</span><span>Django</span></p>
+    </div>
+    <div class="project">
+      <h3>AI Career Platform</h3>
+      <p>Career development system with CV builder and AI recommendations.</p>
+      <p class="tech-list"><span>Python</span><span>Django</span><span>React</span></p>
+    </div>
+    <div class="project">
+      <h3>Co-Work Connect</h3>
+      <p>Workspace booking and scheduling system with admin dashboard.</p>
+      <p class="tech-list"><span>Django</span><span>React</span></p>
+    </div>
+    <div class="project">
+      <h3>USSD Template for Local Market Management</h3>
+      <p>Prototype for managing market transactions via USSD menus.</p>
+      <p class="tech-list"><span>JavaScript</span><span>HTML</span><span>CSS</span></p>
+    </div>
+    <div class="project">
+      <h3>Portfolio Website</h3>
+      <p>Personal developer portfolio site.</p>
+      <p class="tech-list"><span>React</span><span>Django</span></p>
+    </div>
+    <div class="project">
+      <h3>Django-React Tutorial App</h3>
+      <p>Tutorial app with authentication, frontend-backend integration, and deployment.</p>
+      <p class="tech-list"><span>Django</span><span>React</span></p>
+    </div>
+    <div class="project">
+      <h3>Little Lemon Restaurant Website</h3>
+      <p>Restaurant management platform with booking and menu features.</p>
+      <p class="tech-list"><span>Django</span><span>React</span></p>
+    </div>
+    <div class="project">
+      <h3>MOX ERC-20 Token</h3>
+      <p>First ERC-20 token project with smart contract deployment and testing.</p>
+      <p class="tech-list"><span>Vyper</span><span>Ethereum</span><span>Boa</span></p>
+    </div>
+    <div class="project">
+      <h3>BusinessPro</h3>
+      <p>Professional profile website for a client.</p>
+      <p class="tech-list"><span>Django</span><span>React</span></p>
+    </div>
+  </section>
+  <section class="skills">
+    <h2>Skills</h2>
+    <h3>Programming Languages</h3>
+    <p class="tech-list"><span>Python</span><span>JavaScript</span><span>SQL</span><span>Vyper</span></p>
+    <h3>Backend</h3>
+    <p class="tech-list"><span>Django</span><span>Django REST Framework</span></p>
+    <h3>Frontend</h3>
+    <p class="tech-list"><span>React</span><span>React Native</span><span>Tailwind CSS</span></p>
+    <h3>Blockchain</h3>
+    <p class="tech-list"><span>Vyper</span><span>Ethereum</span><span>Moccasin</span><span>Boa</span></p>
+    <h3>Databases</h3>
+    <p class="tech-list"><span>PostgreSQL</span><span>Oracle</span></p>
+    <h3>DevOps</h3>
+    <p class="tech-list"><span>Docker/Podman</span><span>Kubernetes</span><span>Git</span><span>Ubuntu/Linux</span><span>uv</span></p>
+    <h3>Cloud</h3>
+    <p class="tech-list"><span>Netlify</span><span>Railway</span><span>Heroku</span></p>
+    <h3>Other</h3>
+    <p class="tech-list"><span>REST APIs</span><span>Web scraping</span><span>Automation workflows</span></p>
+  </section>
+  <footer>
+    <p>&copy; 2025 Didier IMANIRAHARI</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/portfolio.html` to present profile, projects, and skills in a static layout

## Testing
- `uv run manage.py test` *(fails: Failed to parse uv.lock)*
- `python -m venv .venv && pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement django>=5)*
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ab09b736e4832395d20201a125445a